### PR TITLE
ISSUE-2 - Add dotfiles

### DIFF
--- a/.github/workflows/lint-codebase.yml
+++ b/.github/workflows/lint-codebase.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     paths:
       - '**.swift'
-  push:
-    paths:
-      - '**.swift'
 
 jobs:
   swiftlint:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ DerivedData/
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+.swiftlint.yml

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".dotfiles"]
+	path = .dotfiles
+	url = https://github.com/GetAutomaApp/dotfiles

--- a/Package.swift
+++ b/Package.swift
@@ -9,10 +9,7 @@ let package = Package(
 		.tvOS(.v13),
 	],
     products: [
-        .library(
-            name: "AnyCodable",
-			targets: ["AnyCodable"]
-		),
+        .library(name: "AnyCodable",targets: ["AnyCodable"]),
     ],
     targets: [
         .target(

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "swift-any-codable",
+  "version": "1.0.0",
+  "description": "`AnyCodable` is a Swift package that provides tools to work with heterogeneous or loosely-structured data while maintaining strong type safety and leveraging Swift's powerful `Codable` protocol. It includes support for dynamic coding keys, decoding nested data, and handling any codable value seamlessly.",
+  "main": "index.js",
+  "scripts": {
+    "config": "./.dotfiles/config.sh",
+    "install:swiftlint": "brew install swiftlint",
+    "install:swiftformat": "brew install swiftformat",
+    "install:all": "npx npm-run-all --sequential install:swiftlint install:swiftformat config",
+    "format": "swiftformat .",
+    "lint": "swiftlint --config=.swiftlint.yml ."
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/GetAutomaApp/swift-any-codable.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/GetAutomaApp/swift-any-codable/issues"
+  },
+  "homepage": "https://github.com/GetAutomaApp/swift-any-codable#readme"
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "install:swiftformat": "brew install swiftformat",
     "install:all": "npx npm-run-all --sequential install:swiftlint install:swiftformat config",
     "format": "swiftformat .",
-    "lint": "swiftlint --config=.swiftlint.yml ."
+    "lint": "swiftlint --config=.swiftlint.yml .",
+    "update:submmdules": "git submodule foreach --recursive 'branch=$(git remote show origin | awk \"/HEAD branch/ {print \\$NF}\"); git checkout $branch && git pull origin $branch' && CHANGED=$(git status --porcelain | grep '^ M \\.dotfiles' || true) && if [ -n \"$CHANGED\" ]; then npm run config; fi && git add -A && git commit -m \"chore: update submodules\" || echo 'No changes to commit'",
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Reason

This repo after being forked wasn't touched a lot, but some of the code decisions we make in here might not be synced with the rest of our repositories. This PR only implements whats needed to start running swiftlint & swiftformat locally!

# Tech Details List

- Adds dotfiles
- Ignores .swiftlint.yml file (symlinked via the .dotfiles repo)
- Adds all the required commands to update submodules & configure

**Links:**

[ISSUE-2](https://github.com/GetAutomaApp/AutomaInfraCore/issues/2)
closes/resolves #2

# Testing

**Steps:**
1. Ensure that the linting passes (might fail if there is a violation)
2. Ensure you can run linting locally & the install:all command works
3. Ensure the commands to update the submodules also works
